### PR TITLE
Add good lando defaults

### DIFF
--- a/.lando.upstream.yml
+++ b/.lando.upstream.yml
@@ -1,15 +1,18 @@
 # This file sets some good defaults for the local development of a platform.sh
-# laravel project using lando
+# Laravel project using Lando.
 #
 # Note that you should not edit this file so it can continue to receive upstream
-# updates. If you wish to change the values you simply override them in your
-# normal .lando.yml
+# updates. If you wish to change the values below then override them in your
+# normal .lando.yml.
 
 config:
   # Generally this section overrides production variables and settings for
-  # values that make more sense for local development
-  # Note that "app" is the name of one of your platform applications
-  # Note that the syntax under each app is the same as the format defined here
+  # values that make more sense for local development.
+  #
+  # Note that "app" is the name of the application defined in your
+  # .platform.app.yaml.
+  #
+  # Note that the syntax under each app is the same as the format defined here:
   # https://docs.platform.sh/configuration/app/variables.html
   variables:
     app:
@@ -18,7 +21,7 @@ config:
         APP_DEBUG: 1
 
 
-# These are Laravel specific tools that are commonly used during development
+# These are Laravel specific tools that are commonly used during development.
 tooling:
   artisan:
     cmd: /app/artisan

--- a/.lando.upstream.yml
+++ b/.lando.upstream.yml
@@ -1,0 +1,26 @@
+# This file sets some good defaults for the local development of a platform.sh
+# laravel project using lando
+#
+# Note that you should not edit this file so it can continue to receive upstream
+# updates. If you wish to change the values you simply override them in your
+# normal .lando.yml
+
+config:
+  # Generally this section overrides production variables and settings for
+  # values that make more sense for local development
+  # Note that "app" is the name of one of your platform applications
+  # Note that the syntax under each app is the same as the format defined here
+  # https://docs.platform.sh/configuration/app/variables.html
+  variables:
+    app:
+      env:
+        APP_ENV: development
+        APP_DEBUG: 1
+
+
+# These are Laravel specific tools that are commonly used during development
+tooling:
+  artisan:
+    cmd: /app/artisan
+    service: app
+

--- a/.lando.upstream.yml
+++ b/.lando.upstream.yml
@@ -5,6 +5,11 @@
 # updates. If you wish to change the values below then override them in your
 # normal .lando.yml.
 
+# These both allow you to test this template without needing a site on platform.sh
+# However you will want to replace them in your .lando.yml
+name: laravel-platformsh
+recipe: platformsh
+
 config:
   # Generally this section overrides production variables and settings for
   # values that make more sense for local development.
@@ -26,4 +31,3 @@ tooling:
   artisan:
     cmd: /app/artisan
     service: app
-


### PR DESCRIPTION
@Crell @otaviojava @ralt et all. Previously we had discussed beginning to add `.lando.upstream.yml` files to the the various templates. The purpose of these would be to set "good defaults" for local development. These values can be overridden by the primary `.lando.yml` should the user wish to diverge.

Specifically we wanted to use these to:

* Provide framework specific Lando "tooling" commands that cannot be reliably inferred from any platform config eg "lando drush" or "lando artisan". 
* Override any production "variables" with values that make more sense for localdev eg `APP_ENV: development` or `d8settings:skip_permissions_hardening: 1`
* To do all of the above explicitly e.g. in a config file that is in the repo so the user is not surprised by any undeclared "automagic" we are doing behind the scenes.

Here is a starting point for the Laravel one. Note that the specific envvars here were a best guess based mostly on intuition so feel free to modify as needed. Also note that this file by itself is not sufficient to "lando start" this template since it does not contain required things like a `name` or an associated `platform` site id. That said, IN THE FUTURE, it would be cool if a user could just `git clone && lando start` this template.