### PR TITLE
Add guards around copy_lib and enable_lib

### DIFF
--- a/install-redis.sh
+++ b/install-redis.sh
@@ -8,8 +8,13 @@ run() {
         compile_source
     fi
 
-    copy_lib
-    enable_lib
+    if [ ! -f "${PLATFORM_APP_DIR}/redis.so" ]; then
+        copy_lib
+    fi
+
+    if ! grep "extension=${PLATFORM_APP_DIR}/redis.so" $PLATFORM_APP_DIR/php.ini -q; then
+        enable_lib
+    fi
 }
 
 enable_lib() {


### PR DESCRIPTION
@Crell i know we are planning on sunsetting `install-redis.sh` soonish but this was easy enough to do. Here is the `tl;dr` on the change

Lando currently uses the `platform` CLI's `platform local:build` to "mimic" the build step. The FIRST TIME this happens on the initial `lando start` things work as expected. However, in subsequent `lando rebuild`s we are not starting from the same "clean slate" that exists on the platform itself eg the mods to "php.ini" and "redis.so" are still there. For reasons unclear to me on these subsequent lando builds `platform local:build` segfaults on the `copy_lib` step. Less fatally but to avoid warnings being printed this also stops multiple lines of the same extension being added to `php.ini` during `enable_lib`.

Probably worth looking into that but path of least resistance was to just throw up some guards esp since 