### PR TITLE
Disallow Server config file download.

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -63,6 +63,10 @@ web:
                 - index.php
             allow: true
             passthru: "/index.php"
+            rules:
+              '\.(htaccess|config)$':
+                allow: false
+                expires: -1
         "/storage":
             root: "storage/app/public"
             scripts: false


### PR DESCRIPTION
Laravel comes with pre-defined server configuration files (`.htaccess` for apache servers and `web.config` for IIS). Because those files are located in the mounted `public` directory, it is currently possible to download them by visiting the URI with the file path (e.g. from the #17 build on this repository: https://www.pr-17-tkqs2aa-542kvzau4h5fc.eu-3.platformsh.site/.htaccess).

This change is to explicitly disallow access to .htaccess and .config files.