### PR TITLE
Upgrade to php8 and remove build flavor

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -5,18 +5,16 @@
 name: app
 
 # The type of the application to build.
-type: php:7.4
+type: 'php:8.0'
 
+# Indicate that we want to use composer2, (leave out if you want composer1)
 dependencies:
-    php:
+    php: 
         composer/composer: '^2'
 
 runtime:
     extensions:
         - redis
-
-build:
-    flavor: composer
 
 # The hooks that will be performed when the package is deployed.
 hooks:


### PR DESCRIPTION
No reason to have build flavor composer, since it's the default. 
upgrading to php8 is probably not a bad idea at this point