### PR TITLE
Bug/33 crons

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -93,30 +93,21 @@ web:
             root: "storage/app/public"
             scripts: false
 
-crons:
-    # Run Laravel's scheduler every 5 minutes, which is often as crons can run on Professional plans.
-    scheduler:
-        spec: '*/5 * * * *'
-        cmd: 'php artisan schedule:run'
-    # Run Laravel's queue worker task every 9 minutes
-    queue:
-        spec: '*/9 * * * *'
-        # Allow the worker to run for up to 5 minutes. That prevents
-        # a long-running queue from blocking a deploy for more than 5
-        # minutes.
-        cmd: 'php artisan queue:work --max-time=300'
+# Note that use of workers require a Medium plan or larger.
+workers:
+  queue:
+    size: S
+    commands:
+      # To minimize leakage, the queue worker will stop every hour
+      # and get restarted automatically.
+      start: |
+        php artisan queue:work --max-time=3600
+  scheduler:
+    size: S
+    commands:
+      start: php artisan schedule:work
 
-# If you have an especially large queue, you may be better off using a worker.
-# If so, comment out the `queue` cron entry and uncomment this instead. Note that
-# Doing so requires a Medium plan or larger.
-#workers:
-#    queue:
-#        size: S
-#        commands:
-#            # To minimize leakage, the queue worker will stop every hour
-#            # and get restarted automatically.
-#            start: |
-#                php artisan queue:work --max-time=3600
+
 
 source:
   operations:

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -102,10 +102,14 @@ workers:
       # and get restarted automatically.
       start: |
         php artisan queue:work --max-time=3600
+    # set the worker's disk to the minimum amount
+    disk: 256
   scheduler:
     size: S
     commands:
       start: php artisan schedule:work
+    # set the worker's disk to the minimum amount
+    disk: 256
 
 
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,21 @@ Laravel is an opinionated, integrated rapid-application-development framework fo
 
 ## Features
 
-* PHP 7.4
+* PHP 8.0
 * MariaDB 10.4
 * Redis 5.0
 * Automatic TLS certificates
 * Composer-based build
+
+## Notice
+On Platform.sh the [minimum time between cron jobs](https://docs.platform.sh/create-apps/app-reference.html#cron-job-timing) 
+being triggered depends on your plan. [Laravel documentation](https://laravel.com/docs/7.x/scheduling) suggests running 
+the scheduler as a cron job every minute. Task scheduling may then be contradicted by the cron minimum frequency. 
+Schedules outside the specified cron frequency are ignored and the related tasks aren’t triggered. 
+
+Due to this conflict, this Laravel template utilizes [workers](https://docs.platform.sh/create-apps/workers.html) to run 
+both the scheduler and the queue systems. In order to have enough resources to support these workers as well as the 
+MariaDB and Redis service, **this template requires at least a [Medium plan](https://docs.platform.sh/administration/pricing.html#multiple-apps-in-a-single-project).**
 
 ## Customizations
 


### PR DESCRIPTION
## Description

- Removes crons
- Adds workers as a replacement for removed crons
- Updates README

See issue #33 

## Related Issue
#33 

## Motivation and Context
Crons on Professional plans have a minimum of 5 minutes between cron runs, and a [jitter of 20 minutes](https://platform.sh/blog/increasing-cron-jitter/). Given that the Laravel docs suggest running the `schedule:run` as a cron scheduled for every minute, scheduled jobs will be missed/skipped.  


